### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/picas/clients.py
+++ b/picas/clients.py
@@ -190,7 +190,8 @@ class CouchDB(object):
                       % (doc.id, doc.rev, str(ex)), file=sys.stderr)
                 result[i] = False
             except Exception as ex:
-                print("Could not delete document {0!s}: {1!s}".format(str(doc), str(ex)), file=sys.stderr)
+                print("Could not delete document {0!s}: {1!s}".
+                      format(str(doc), str(ex)), file=sys.stderr)
                 result[i] = False
 
         return result

--- a/picas/clients.py
+++ b/picas/clients.py
@@ -190,8 +190,7 @@ class CouchDB(object):
                       % (doc.id, doc.rev, str(ex)), file=sys.stderr)
                 result[i] = False
             except Exception as ex:
-                print("Could not delete document %s: %s"
-                      % (str(doc), str(ex)), file=sys.stderr)
+                print("Could not delete document {0!s}: {1!s}".format(str(doc), str(ex)), file=sys.stderr)
                 result[i] = False
 
         return result

--- a/picas/srmclient.py
+++ b/picas/srmclient.py
@@ -27,7 +27,7 @@ def download(files, threads=10):
     q.join()
     print("Download work done, joining threads")
     for d in thread_pool:
-        print("Joining: %s" % str(d.ident))
+        print("Joining: {0!s}".format(str(d.ident)))
         d.join(1)
 
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:sara-nl:picasclient?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:sara-nl:picasclient?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)