### PR TITLE
Update processing to be more general

### DIFF
--- a/examples/process_task.sh
+++ b/examples/process_task.sh
@@ -22,7 +22,7 @@ echo $TOKENID
 echo $OUTPUT
 
 #Start processing
-eval $INPUT
+bash -c "$INPUT"
 if [[ "$?" != "0" ]]; then
     echo "Program interrupted. Exit now..."
     exit 1


### PR DESCRIPTION
The eval implementation assumes certain forms for input which results in complex strings from the token to be parsed into commands. This is unwanted, as programs can generate quite complicated commands in string form, with different shapes (for safety for ex.) like single-, double- quotes, backticks, and other characters that bash, python and json may interpret/parse differently.

The implementation in this commit changes the bash part to leave the input string intact, and not split it into pieces. Moreover, the shell part of python is changed into default behaviour of subprocess, along with listing the input, which also helps with parsing complex strings properly.

This was tested with string containing escaped characters in nested and nonnested forms, and is more robust:

echo 'Single quote' && echo \"Double quote\" && echo   && echo \\Escaped backslash\\
echo "this is a test"; echo 'nesting with "double quotes" and `backticks`'
(This is probably already parsed and reparsed by the github comments)