### PR TITLE
SPD-417: add scanner and get resources from tokens

### DIFF
--- a/examples/autopilot/README
+++ b/examples/autopilot/README
@@ -1,0 +1,18 @@
+Autopiloting
+============
+
+This example shows how to automatically start a picas client (or pilot) to process tokens from the database.
+While this example explicitly shows the case of two types of tokens, that is single-core and multi-core work, you can adjust the code to:
+ - Run for a single view, such as your default tokens.
+ - Add more than the 2 views, to process as many types of tokens as you want (where type could also be GPU, high-memory, or other properties of a job).
+ - Add properties to the tokens in your "pushTokens" code, such as 
+    - "gpu: 1" and start a GPU-based job
+    - "time: 72:00:00" and then start a job with a 3-day walltime
+    - "cores: 8" and start a high-memory job
+
+This can be achieved by adjusting:
+ 1. The view code to create all the necessary views
+ 2. The scanner code to scan these views and submit the necessary jobs
+ 3. The job scripts (.sh) that end up in slurm / your scheduler
+ 4. The pilot jobs that scan the views containing the work
+ 5. Finally, The tokens need to be available in your database

--- a/examples/autopilot/README
+++ b/examples/autopilot/README
@@ -17,7 +17,33 @@ This can be achieved by adjusting:
  4. The pilot jobs that scan the views containing the work
  5. Finally, The tokens need to be available in your database
 
-Running autopilot
-=================
-To run the scanner on a schedule, one can start it using (in slurm) scrontab, as described in https://doc.spider.surfsara.nl/en/latest/Pages/workflows.html#recurring-jobs and https://slurm.schedmd.com/scrontab.html
+Running the autopilot
+=====================
 
+In this example, two types of tokens are to be executed: single-core tokens and multi-core (4 cores) tokens. It is written for a slurm cluster, so the user may have to adjust the code if they want to run it elsewhere.
+And like the examples in the root exmample folder, a running CouchDB instance is needed.
+To run this example, do:
+
+```
+source setup.sh
+python createViews.py
+```
+
+to add the picasconfig to your `PYTHONPATH` and to create the views needed in your CouchDB instance. Next, run 
+
+```
+python pushAutoPilotExampleTokens.py
+```
+
+to push the relevant tokens. Next you can start scanning for work with:
+
+```
+python core-scanner.py
+```
+
+And this process will start the picas clients needed to process your tokens. The process will see single-core tokens and multi-core tokens and start two jobs on the cluster:
+one job with 1 core, and one job with 4 cores, to process the different kinds of work that require differing resources.
+
+Running autopilot on a schedule
+===============================
+To run the scanner on a schedule, one can start it using (in slurm) scrontab, as described in https://doc.spider.surfsara.nl/en/latest/Pages/workflows.html#recurring-jobs and https://slurm.schedmd.com/scrontab.html or other automation tools.

--- a/examples/autopilot/README
+++ b/examples/autopilot/README
@@ -16,3 +16,8 @@ This can be achieved by adjusting:
  3. The job scripts (.sh) that end up in slurm / your scheduler
  4. The pilot jobs that scan the views containing the work
  5. Finally, The tokens need to be available in your database
+
+Running autopilot
+=================
+To run the scanner on a schedule, one can start it using (in slurm) scrontab, as described in https://doc.spider.surfsara.nl/en/latest/Pages/workflows.html#recurring-jobs and https://slurm.schedmd.com/scrontab.html
+

--- a/examples/autopilot/core-scanner.py
+++ b/examples/autopilot/core-scanner.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+
+import logging
+import sys
+
+import picasconfig
+from picas.picaslogger import picaslogger
+from picas.clients import CouchDB
+from picas.executers import execute
+
+picaslogger.propagate = False
+
+client = CouchDB(url=picasconfig.PICAS_HOST_URL, db=picasconfig.PICAS_DATABASE, username=picasconfig.PICAS_USERNAME, password=picasconfig.PICAS_PASSWORD)
+work_1c_avail = client.is_view_nonempty("todo1c", design_doc="MonitorCores")
+work_4c_avail = client.is_view_nonempty("todo4c", design_doc="MonitorCores")
+
+if work_1c_avail and work_4c_avail:
+    picaslogger.info(f"Starting a picas clients checking view todo1c and view todo4c")
+    command = ["sbatch", "single-core-job.sh"]
+    execute(command)
+    command = ["sbatch", "multi-core-job.sh"]
+    execute(command)
+elif work_1c_avail:
+    picaslogger.info(f"Starting a picas client checking view todo1c")
+    command = ["sbatch", "single-core-job.sh"]
+    execute(command)
+elif work_4c_avail:
+    picaslogger.info(f"Starting a picas client checking view todo4c")
+    command = ["sbatch", "multi-core-job.sh"]
+    execute(command)
+else:
+    picaslogger.info(f"Not starting a picas client, there is nothing to do in views todo1c and todo4c")

--- a/examples/autopilot/createViews.py
+++ b/examples/autopilot/createViews.py
@@ -1,0 +1,93 @@
+'''
+@helpdesk: SURF helpdesk <helpdesk@surf.nl>
+
+usage: python createViews.py [picas_db_name] [picas_username] [picas_pwd]
+description: create the following Views in [picas_db_name]:
+    todo 1 core View : lock_timestamp == 0 && done_timestamp == 0 && cores == 1
+    todo 4 core View : lock_timestamp == 0 && done_timestamp == 0 && cores == 4
+    locked View : lock_timestamp > 0 && done_timestamp == 0
+    done View : lock_timestamp > 0 && done _timestamp > 0 && exit_code == 0
+    error View : lock_timestamp > 0 && done _timestamp > 0 && exit_code != 0
+    overview_total View : sum tokens per View (Map/Reduce)
+'''
+
+import couchdb
+from couchdb.design import ViewDefinition
+import picasconfig
+
+
+def createViews(db):
+    generalViewCode='''
+function(doc) {
+   if(doc.type == "token") {
+    if(%s) {
+      emit(doc._id, doc._id);
+    }
+  }
+}
+'''
+    # todo 1 core View
+    todoCondition = 'doc.lock == 0 && doc.done == 0 && doc.cores == 1'
+    todo_view = ViewDefinition('MonitorCores', 'todo1c', generalViewCode %(todoCondition))
+    todo_view.sync(db)
+    # todo 4 cores View
+    todoCondition = 'doc.lock == 0 && doc.done == 0 && doc.cores == 4'
+    todo_view = ViewDefinition('MonitorCores', 'todo4c', generalViewCode %(todoCondition))
+    todo_view.sync(db)
+    # locked View
+    lockedCondition = 'doc.lock > 0 && doc.done == 0'
+    locked_view = ViewDefinition('MonitorCores', 'locked', generalViewCode %(lockedCondition))
+    locked_view.sync(db)
+    # done View
+    doneCondition = 'doc.lock > 0 && doc.done > 0 && parseInt(doc.exit_code) == 0'
+    done_view = ViewDefinition('MonitorCores', 'done', generalViewCode %(doneCondition))
+    done_view.sync(db)
+    # error View
+    errorCondition = 'doc.lock > 0 && doc.done > 0 && parseInt(doc.exit_code) != 0'
+    error_view = ViewDefinition('MonitorCores', 'error', generalViewCode %(errorCondition))
+    error_view.sync(db)
+    # overview_total View -- lists all views and the number of tokens in each view
+    overviewMapCode='''
+function(doc) {
+   if(doc.type == "token") {
+       if (doc.lock == 0 && doc.done == 0 && doc.cores == 1){
+          emit('todo1c', 1);
+       }
+       if (doc.lock == 0 && doc.done == 0 && doc.cores == 4){
+          emit('todo4c', 1);
+       }
+       if(doc.lock > 0 && doc.done == 0) {
+          emit('locked', 1);
+       }
+       if(doc.lock > 0 && doc.done > 0 && parseInt(doc.exit_code) == 0) {
+          emit('done', 1);
+       }
+       if(doc.lock > 0 && doc.done > 0 && parseInt(doc.exit_code) != 0) {
+          emit('error', 1);
+       }
+   }
+}
+'''
+    overviewReduceCode='''
+function (key, values, rereduce) {
+   return sum(values);
+}
+'''
+    overview_total_view = ViewDefinition('MonitorCores', 'overview_total', overviewMapCode, overviewReduceCode)
+    overview_total_view.sync(db)
+
+
+def get_db():
+    server = couchdb.Server(picasconfig.PICAS_HOST_URL)
+    username = picasconfig.PICAS_USERNAME
+    pwd = picasconfig.PICAS_PASSWORD
+    server.resource.credentials = (username, pwd)
+    db = server[picasconfig.PICAS_DATABASE]
+    return db
+
+
+if __name__ == '__main__':
+    # Create a connection to the server
+    db = get_db()
+    # Create the Views in database
+    createViews(db)

--- a/examples/autopilot/multi-core-job.sh
+++ b/examples/autopilot/multi-core-job.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+#SBATCH -c 4
+
+python multi-core-pilot.py

--- a/examples/autopilot/multi-core-pilot.py
+++ b/examples/autopilot/multi-core-pilot.py
@@ -1,0 +1,27 @@
+"""
+@helpdesk: SURF helpdesk <helpdesk@surf.nl>
+
+usage: python multi-core-pilot.py
+description:
+    This is part of the example of scanning a CouchDB database and checking if multiple
+    views contain work, where the work is either single-core work (single-core-job.sh and 
+    single-core-pilot.py) or multi-core work (multi-core-job.sh and multi-core-pilot.py).
+    To run the full example, start the scanner through `python core-scanner.py`
+"""
+
+
+from picas.clients import CouchDB
+from picas.modifiers import BasicTokenModifier
+
+from examples import picasconfig
+from examples.local_example import ExampleActor
+
+def main():
+    client = CouchDB(url=picasconfig.PICAS_HOST_URL, db=picasconfig.PICAS_DATABASE, username=picasconfig.PICAS_USERNAME, password=picasconfig.PICAS_PASSWORD)
+    print("Connected to the database %s sucessfully. Now starting work..." %(picasconfig.PICAS_DATABASE))
+    modifier = BasicTokenModifier()
+    actor = ExampleActor(client, modifier, view="todo4c", design_doc="MonitorCores")
+    actor.run(max_total_time=10)
+
+if __name__ == '__main__':
+    main()

--- a/examples/autopilot/process_task.sh
+++ b/examples/autopilot/process_task.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+#@helpdesk: SURF helpdesk <helpdesk@surf.nl>
+#
+# usage: ./process_task.sh [input] [tokenid]
+
+
+#Enable verbosity 
+set -x
+
+#Obtain information for the Worker Node
+echo ""
+echo `date`
+echo ${HOSTNAME}
+
+#Initialize job arguments
+INPUT=$1      
+TOKENID=$2
+OUTPUT=output_${TOKENID}
+echo $INPUT
+echo $TOKENID
+echo $OUTPUT
+
+#Start processing
+bash -c "$INPUT"
+if [[ "$?" != "0" ]]; then
+    echo "Program interrupted. Exit now..."
+    exit 1
+fi
+
+echo `date`
+
+exit 0

--- a/examples/autopilot/pushAutoPilotExampleTokens.py
+++ b/examples/autopilot/pushAutoPilotExampleTokens.py
@@ -1,0 +1,57 @@
+'''
+@helpdesk: SURF helpdesk <helpdesk@surf.nl>
+
+usage: python pushTokens.py
+description:
+   Connects to PiCaS server
+   Creates three tokens, two for single-core, one for multi-core
+   Loads the tokens
+'''
+
+import sys
+import os
+import couchdb
+import random
+
+from examples import picasconfig
+
+def getNextIndex():
+    db = get_db()
+    
+    index = 0
+    while db.get(f"token_{index}") is not None:
+        index+=1
+
+    return index
+
+def loadTokens(db, ncores=1):
+    i = getNextIndex()
+
+    token = {
+        '_id': 'token_' + str(i),
+        'type': 'token',
+        'lock': 0,
+        'done': 0,
+        'hostname': '',
+        'scrub_count': 0,
+        'input': 'echo $SLURM_CPUS_PER_TASK',
+        'exit_code': '',
+        'cores': f'{ncores}'
+    }
+    db.update([token])
+
+def get_db():
+    server = couchdb.Server(picasconfig.PICAS_HOST_URL)
+    username = picasconfig.PICAS_USERNAME
+    pwd = picasconfig.PICAS_PASSWORD
+    server.resource.credentials = (username,pwd)
+    db = server[picasconfig.PICAS_DATABASE]
+    return db
+
+if __name__ == '__main__':
+   #Create a connection to the server
+   db = get_db()
+   #Load the tokens to the database
+   loadTokens(db, ncores=1)
+   loadTokens(db, ncores=1)
+   loadTokens(db, ncores=4)

--- a/examples/autopilot/setup.sh
+++ b/examples/autopilot/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+SCRIPT_PATH=$(cd "$(dirname "${BASH_SOURCE[0]}")"; cd ..; pwd)
+export PYTHONPATH=$SCRIPT_PATH:$PYTHONPATH

--- a/examples/autopilot/single-core-job.sh
+++ b/examples/autopilot/single-core-job.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+#SBATCH -c 1
+
+python single-core-pilot.py

--- a/examples/autopilot/single-core-pilot.py
+++ b/examples/autopilot/single-core-pilot.py
@@ -1,0 +1,27 @@
+"""
+@helpdesk: SURF helpdesk <helpdesk@surf.nl>
+
+usage: python single-core-pilot.py
+description:
+    This is part of the example of scanning a CouchDB database and checking if multiple
+    views contain work, where the work is either single-core work (single-core-job.sh and 
+    single-core-pilot.py) or multi-core work (multi-core-job.sh and multi-core-pilot.py).
+    To run the full example, start the scanner through `python core-scanner.py`
+"""
+
+
+from picas.clients import CouchDB
+from picas.modifiers import BasicTokenModifier
+
+from examples import picasconfig
+from examples.local_example import ExampleActor
+
+def main():
+    client = CouchDB(url=picasconfig.PICAS_HOST_URL, db=picasconfig.PICAS_DATABASE, username=picasconfig.PICAS_USERNAME, password=picasconfig.PICAS_PASSWORD)
+    print("Connected to the database %s sucessfully. Now starting work..." %(picasconfig.PICAS_DATABASE))
+    modifier = BasicTokenModifier()
+    actor = ExampleActor(client, modifier, view="todo1c", design_doc="MonitorCores")
+    actor.run(max_total_time=10)
+
+if __name__ == '__main__':
+    main()

--- a/examples/grid-example.jdl
+++ b/examples/grid-example.jdl
@@ -7,6 +7,6 @@
   Arguments = "startpilot.sh";
   Stdoutput = "parametricjob.out";
   StdError = "parametricjob.err";
-  InputSandbox = {"grid-sandbox/CouchDB-1.2.tar.gz", "grid-sandbox/picas.tar", "grid-sandbox/startpilot.sh", "local-example.py", "grid-sandbox/process_task.sh", "bin/fractals", "picasconfig.py"};
+  InputSandbox = {"grid-sandbox/CouchDB-1.2.tar.gz", "grid-sandbox/picas.tar", "grid-sandbox/startpilot.sh", "local_example.py", "grid-sandbox/process_task.sh", "bin/fractals", "picasconfig.py"};
   OutputSandbox = {"parametricjob.out", "parametricjob.err"};
 ]

--- a/examples/grid-sandbox/startpilot.sh
+++ b/examples/grid-sandbox/startpilot.sh
@@ -20,4 +20,4 @@ chmod u+x ${JOBDIR}/process_task.sh
 chmod u+x ${JOBDIR}/fractals
 ls -l ${JOBDIR}
 
-python ${JOBDIR}/local-example.py
+python ${JOBDIR}/local_example.py

--- a/examples/local_example.py
+++ b/examples/local_example.py
@@ -1,7 +1,7 @@
 '''
 @helpdesk: SURF helpdesk <helpdesk@surf.nl>
 
-usage: python local-example.py
+usage: python local_example.py
 description:
     Connect to PiCaS server
     Get the next token in todo View

--- a/examples/local_example.py
+++ b/examples/local_example.py
@@ -15,7 +15,6 @@ import logging
 import os
 import time
 import couchdb
-import picasconfig
 
 from picas.actors import RunActor
 from picas.clients import CouchDB
@@ -24,6 +23,7 @@ from picas.iterators import TaskViewIterator
 from picas.iterators import EndlessViewIterator
 from picas.modifiers import BasicTokenModifier
 from picas.util import Timer
+from . import picasconfig
 
 log = logging.getLogger(__name__)
 

--- a/examples/slurm-example.sh
+++ b/examples/slurm-example.sh
@@ -18,4 +18,4 @@ cd $PWD
 # You need to load your environment here
 # mamba activate MAMBA-ENV
 # source /PATH/TO/VENV/bin/activate
-python local-example.py
+python local_example.py

--- a/examples/snakemake.jdl
+++ b/examples/snakemake.jdl
@@ -8,7 +8,7 @@
   Arguments = "startpilot.sh";
   Stdoutput = "parametricjob.out";
   StdError = "parametricjob.err";
-  InputSandbox = {"grid-sandbox/CouchDB-1.2.tar.gz", "grid-sandbox/picas.tar", "grid-sandbox/startpilot.sh", "local-example.py", "grid-sandbox/process_task.sh", "picasconfig.py", 
+  InputSandbox = {"grid-sandbox/CouchDB-1.2.tar.gz", "grid-sandbox/picas.tar", "grid-sandbox/startpilot.sh", "local_example.py", "grid-sandbox/process_task.sh", "picasconfig.py",
                   "grid-sandbox/Snakefile", "grid-sandbox/plot-quals.py"};
   OutputSandbox = {"parametricjob.out", "parametricjob.err"};
 ]


### PR DESCRIPTION
This merge will add the ability to scan a token for
1. Availability: Is there a token in a view?
2. Add resource-dependent clients: start a client based on information in a token

In this way a user can "just scan for tokens and start a client" if needed, and extend to multiple clients based on resource requirements in the tokens.