### PR TITLE
Add python3.13 to CICD

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 python = "^3.10"
 couchdb = "^1.2"
 stopit = "^1.1.2"
+setuptools = "^66"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^8.3.3"


### PR DESCRIPTION
Python 3.13 was released recently, let's include it in the pipeline and see if it works.