### PR TITLE
Fix SSLEOFError when connection to DB is lost

### DIFF
--- a/picas/actors.py
+++ b/picas/actors.py
@@ -49,11 +49,9 @@ class AbstractRunActor(object):
         else:
             self.iterator = iterator
 
-
     def reconnect(self):
         self.db = self.db.copy()
         self.iterator.reconnect(self.db)
-
 
     def _run(self, task, timeout):
         """
@@ -88,20 +86,20 @@ class AbstractRunActor(object):
             # SSLEOFError can occur for long-lived connections, re-establish connection
             msg = f"Warning: {type(ex)} occurred while saving task to database: " + \
                 "Trying ro reconnect to database"
-            log.info(msg)        
+            log.info(msg)
             self.reconnect()
             try:
                 self.db.save(task)
-            except:
+            except Exception as ex:
                 msg = f"Error: {type(ex)} occurred while saving task to database: " + \
                     "Not able to reconnect to database"
-                log.info(msg)                 
+                log.info(msg)
                 raise
         except Exception as ex:
-            #re-raise unknown exception, this will terminate the iterator
+            # re-raise unknown exception, this will terminate the iterator
             msg = f"Error: {type(ex)} occurred while saving task to database: {ex}"
             log.info(msg)
-            raise 
+            raise
 
         self.cleanup_run()
         self.tasks_processed += 1

--- a/picas/actors.py
+++ b/picas/actors.py
@@ -5,6 +5,7 @@
 @author: Jan Bot, Joris Borgdorff
 """
 
+import ssl
 import logging
 import signal
 import subprocess
@@ -48,6 +49,12 @@ class AbstractRunActor(object):
         else:
             self.iterator = iterator
 
+
+    def reconnect(self):
+        self.db = self.db.copy()
+        self.iterator.reconnect(self.db)
+
+
     def _run(self, task, timeout):
         """
         Execution of the work on the iterator used in the run method.
@@ -70,12 +77,31 @@ class AbstractRunActor(object):
 
         try:
             self.db.save(task)
-        except Exception as ex:
+        except ResourceConflict as ex:
             # simply overwrite changes - model results are more important
-            msg = f"Warning: {type(ex)} occurred while saving task to database: {ex}"
+            msg = f"Warning: {type(ex)} occurred while saving task to database: " + \
+                "Document exists with different revision or was deleted"
             log.info(msg)
             new_task = self.db.get(task.id)
             task['_rev'] = new_task.rev
+        except ssl.SSLEOFError as ex:
+            # SSLEOFError can occur for long-lived connections, re-establish connection
+            msg = f"Warning: {type(ex)} occurred while saving task to database: " + \
+                "Trying ro reconnect to database"
+            log.info(msg)        
+            self.reconnect()
+            try:
+                self.db.save(task)
+            except:
+                msg = f"Error: {type(ex)} occurred while saving task to database: " + \
+                    "Not able to reconnect to database"
+                log.info(msg)                 
+                raise
+        except Exception as ex:
+            #re-raise unknown exception, this will terminate the iterator
+            msg = f"Error: {type(ex)} occurred while saving task to database: {ex}"
+            log.info(msg)
+            raise 
 
         self.cleanup_run()
         self.tasks_processed += 1

--- a/picas/actors.py
+++ b/picas/actors.py
@@ -70,18 +70,12 @@ class AbstractRunActor(object):
 
         try:
             self.db.save(task)
-        except ResourceConflict as ex:
+        except Exception as ex:
             # simply overwrite changes - model results are more important
-            msg = f"Warning: {type(ex)} occurred while saving task to database: " + \
-                "Document exists with different revision or was deleted"
+            msg = f"Warning: {type(ex)} occurred while saving task to database: {ex}"
             log.info(msg)
             new_task = self.db.get(task.id)
             task['_rev'] = new_task.rev
-        except Exception as ex:
-            # re-raise Exception
-            msg = f"Error: {type(ex)} occurred while saving task to database: {ex}"
-            log.info(msg)
-            raise
 
         self.cleanup_run()
         self.tasks_processed += 1

--- a/picas/iterators.py
+++ b/picas/iterators.py
@@ -56,6 +56,10 @@ class ViewIterator:
     def claim_task(self):
         """Get the first available task from a view."""
         raise NotImplementedError("claim_task function not implemented.")
+    
+    def reconnect(self, database):
+        """Reconnect to database"""
+        self.database = database
 
 
 def _claim_task(database, view, allowed_failures=10, **view_params):

--- a/picas/iterators.py
+++ b/picas/iterators.py
@@ -56,7 +56,7 @@ class ViewIterator:
     def claim_task(self):
         """Get the first available task from a view."""
         raise NotImplementedError("claim_task function not implemented.")
-    
+
     def reconnect(self, database):
         """Reconnect to database"""
         self.database = database

--- a/tests/test_actors.py
+++ b/tests/test_actors.py
@@ -3,6 +3,7 @@ import signal
 import subprocess
 import time
 import unittest
+import ssl
 
 from test_mock import MockDB, MockEmptyDB
 from unittest.mock import patch
@@ -71,6 +72,16 @@ class TestRun(unittest.TestCase):
         runner = ExampleRun(self._callback)
         runner._run(task=Task({'_id': 'c', 'lock': None, 'done': None}), timeout=None)
         self.assertEqual(runner.tasks_processed, 1)
+
+    @patch('test_mock.MockDB.save')
+    def test_run_ssleoferror(self, mock_save):
+        """
+        Test the _run function, in case the DB throws a an SSLEOFError
+        """
+        with pytest.raises(ssl.SSLEOFError):
+            mock_save.side_effect = ssl.SSLEOFError
+            runner = ExampleRun(self._callback)
+            runner._run(task=Task({'_id': 'c', 'lock': None, 'done': None}), timeout=None)
 
     @patch('test_mock.MockDB.save')
     def test_run_exception(self, mock_save):

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -41,6 +41,9 @@ class MockDB(object):
 
         return doc
 
+    def copy(self):
+        return self
+
 
 class MockEmptyDB(MockDB):
     TASKS = []


### PR DESCRIPTION
For long-lived jobs, the connection to CouchDB can be lost. The code than crashes with an SSLEOFError and the tokens stay locked. This PR fixes that by reconnecting to the DB when this happens.