### PR TITLE
Function handler for write and staging events

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,10 +413,10 @@ To run the scanner on a schedule, one can start it using (in slurm) scrontab, as
 <summary>dCache event handler</summary>
 
 ### Prerequisites
-In this advanced example, we will subscribe to changes in a given dCache directory and track when a new file is added or staged (i.e. brought online from tape to disk). We can then create tokens when a file becomes available for processing. In order to run this example, you need to have access to dCache. First, create a macaroon tokenfile for dCache authentication according to these [instructions](https://doc.spider.surfsara.nl/en/latest/Pages/storage/ada-interface.html#create-a-macaroon). In the following, it is assumed that your tokenfile is named `tokenfile.conf`. Furthermore, you need to have [ada](https://github.com/sara-nl/SpiderScripts) and [rclone(https://rclone.org/) installed, these are pre-installed on Spider.
+In this advanced example, we will subscribe to changes in a given dCache directory and track when a new file is added or staged (i.e. brought online from tape to disk). We can then create tokens when a file becomes available for processing. In order to run this example, you need to have access to dCache. First, create a macaroon tokenfile for dCache authentication according to these [instructions](https://doc.spider.surfsara.nl/en/latest/Pages/storage/ada-interface.html#create-a-macaroon). In the following, it is assumed that your tokenfile is named `tokenfile.conf`. Furthermore, you need to have [ada](https://github.com/sara-nl/SpiderScripts) and [rclone](https://rclone.org/) installed, these are pre-installed on Spider.
 
 ### Create a token when a file is written to dCache
-With the following command, a channel named "test_write" is created that will register write events to the specified directory `/pnfs/grid.sara.nl/data/users/username/tape/testdir` on dCache. Then, if a write event occurs, a token is created in the "todo" view in the PiCaS database.
+With the following command, a channel named "test_write" is created that will register write events to the specified folder on dCache. Then, if a write event occurs, a token is created in the "todo" view in the PiCaS database.
 
 ```
 python pushEventsTokens.py --folder /pnfs/grid.sara.nl/data/users/username/tape/testdir --tokenfile tokenfile.conf --event write --api https://dcacheview.grid.surfsara.nl:22880/api/v1
@@ -431,18 +431,17 @@ Check the DB; you should see a new token in the view `Monitor/todo`.
 
 ### Create a token when a file is staged on dCache
 
-With the following command, a channel named "test_stage" is created that will register staging events in the specified directory `/pnfs/grid.sara.nl/data/users/username/tape/testdir` on dCache. Then, if a staging event occurs - i.e. a file is brough online - a token is created in the "todo" view in the PiCaS database.
+With the following command, a channel named "test_stage" is created that will register staging events in the specified folder on dCache. Then, if a staging event occurs - i.e. a file is brough online - a token is created in the "todo" view in the PiCaS database.
 
 ```
 python pushEventsTokens.py --folder /pnfs/grid.sara.nl/data/users/username/tape/testdir --tokenfile tokenfile.conf --event stage --api https://dcacheview.grid.surfsara.nl:22880/api/v1
 ```
-You can only test this, when you have a file on dCache that has status "NEARLINE", i.e. is only available on tape and not disk. Check this with:
+You can only test this, when you have a file on dCache that is only available on tape and not on disk. You can check this with:
 
 ```
-ada --tokenfile tokenfile.conf --longlist /pnfs/grid.sara.nl/data/users/hailih/tape/testdir/testfile --api https://dcacheview.grid.surfsara.nl:22880/api/v1
+ada --tokenfile tokenfile.conf --longlist /pnfs/grid.sara.nl/data/users/username/tape/testdir/testfile --api https://dcacheview.grid.surfsara.nl:22880/api/v1
 ```
-
-If so, stage this file with:
+The file should have status "NEARLINE" (ond not "ONLINE_AND_NEARLINE"). If so, stage this file with:
 
 ```
 ada --tokenfile tokenfile.conf --stage /pnfs/grid.sara.nl/data/users/hailih/tape/testfile  --api https://dcacheview.grid.surfsara.nl:22880/api/v1

--- a/examples/pushEventsTokens.py
+++ b/examples/pushEventsTokens.py
@@ -1,17 +1,20 @@
 '''
 @helpdesk: SURF helpdesk <helpdesk@surf.nl>
 
-usage: python pushEventsTokens.py --folder <dCache_directory> --tokenfile <tokenfile> [--event <write/stage>] [--api <dCache_api>]
+usage: python pushEventsTokens.py --dir <dCache_directory> --tokenfile <tokenfile> --event <write/stage> [--api <dCache_api>]
 description:
    Connects to PiCaS server
-   Creates token when file is written to a dCache folder or staged (brought online)
+   Create a channel to listen to events on dCache
+   Creates token when file is written to a dCache directory or staged (brought online)
    Loads the tokens
 '''
+
 
 import argparse
 import couchdb
 import picasconfig
 from subprocess import Popen, PIPE, CalledProcessError
+
 
 def getNextIndex():
     db = get_db()
@@ -51,7 +54,7 @@ def arg_parser():
     returns: argparse object
     """
     parser = argparse.ArgumentParser(description="Subscribe to changes in a given dCache directory and create tokens when a new files are added or staged.")
-    parser.add_argument("--folder", required=True, type=str, help="dCache directory to track")
+    parser.add_argument("--dir", required=True, type=str, help="dCache directory to track")
     parser.add_argument("--tokenfile", required=True, type=str, help="Name of tokenfile containing macaroon")
     parser.add_argument("--event", required=True, type=str, help="Type of event to track, write or stage?")
     parser.add_argument("--api", default="https://dcacheview.grid.surfsara.nl:22880/api/v1", type=str, help="dCache api endpoint")
@@ -67,8 +70,8 @@ if __name__ == '__main__':
     args = arg_parser().parse_args()
 
     # Get configurations from commandline arguments:
-    # dCache folder to follow:
-    folder = args.folder
+    # dCache directory to follow:
+    dir = args.dir
     # tokenfile with macaroon for accessing dCache
     ada_tokenfile = args.tokenfile
     # dCache API endpoint
@@ -78,7 +81,7 @@ if __name__ == '__main__':
 
     if event == "write":
         channel_name = "test_" + event    # channel_name = "test_write"
-        command = ["ada", "--tokenfile", ada_tokenfile, "--events", channel_name, folder, "--api", api, "--resume", "--force"]
+        command = ["ada", "--tokenfile", ada_tokenfile, "--events", channel_name, dir, "--api", api, "--resume", "--force"]
         with Popen(command, stdout=PIPE, stderr=PIPE, bufsize=1, universal_newlines=True) as p:
             for line in p.stdout:
                 print(line, end='')
@@ -92,7 +95,7 @@ if __name__ == '__main__':
                 print(line, end='')
     elif event == "stage":
         channel_name = "test_" + event    #channel_name = "test_staged"
-        command = ["ada", "--tokenfile", ada_tokenfile, "--report-staged", channel_name, folder, "--api", api, "--resume", "--force"]
+        command = ["ada", "--tokenfile", ada_tokenfile, "--report-staged", channel_name, dir, "--api", api, "--resume", "--force"]
         file_change = 0
         filename = ""
         with Popen(command, stdout=PIPE, stderr=PIPE, bufsize=1, universal_newlines=True) as p:


### PR DESCRIPTION
Create a token in PiCaS database when file is written to a dCache directory or staged.
See the advanced example in the README for how to test the functionality.