### PR TITLE
implement logic for giving env vars higher precedence

### DIFF
--- a/examples/picasconfig_example.py
+++ b/examples/picasconfig_example.py
@@ -4,7 +4,6 @@
 #
 # precedence of configuration variables (highest to lowest):
 #   - environment variables
-#   - command line flags
 #   - config.py
 
 PICAS_HOST_URL=""

--- a/picas/picas_config.py
+++ b/picas/picas_config.py
@@ -90,16 +90,43 @@ class PicasConfig:
 
     def load_config(self):
         """
-        Load the configuration yaml file from the specified path and validate against schema.
+        Load the configuration with the following precedence (highest to lowest):
+          - environment variables
+          - the configuration file
+
+        Environment variables:
+          - PICAS_HOST_URL -> host_url
+          - PICAS_DATABASE -> database
+          - PICAS_USERNAME -> username
+          - PICAS_ENCRYPTED_PASSWORD -> the encrypted password
         """
         print(f"load the configuration from {self.config_path}")
         expanded_path = os.path.expanduser(self.config_path)
 
-        if not os.path.exists(expanded_path):
-            raise FileNotFoundError(f"configuration file not found: {self.config_path}")
+        # load from configuration file first (lowest precedence)
+        if os.path.exists(expanded_path):
+            with open(expanded_path, 'r') as fobj:
+                self.config = yaml.safe_load(fobj) or {}
+        else:
+            self.config = {}
 
-        with open(expanded_path, 'r') as fobj:
-            self.config = yaml.safe_load(fobj)
+        # Override with environment variables (highest precedence)
+        env_host_url = os.environ.get('PICAS_HOST_URL')
+        env_database = os.environ.get('PICAS_DATABASE')
+        env_username = os.environ.get('PICAS_USERNAME')
+        env_encrypted_password = os.environ.get('PICAS_ENCRYPTED_PASSWORD')
+
+        if env_host_url:
+            self.config['host_url'] = env_host_url
+
+        if env_database:
+            self.config['database'] = env_database
+
+        if env_username:
+            self.config['username'] = env_username
+
+        if env_encrypted_password:
+            self.config['encrypted_password'] = env_encrypted_password
 
         self.validate_config()
 


### PR DESCRIPTION
This pull request updates the configuration loading logic to clarify and enforce the precedence of environment variables over configuration files, and removes mention of command line flags from the configuration precedence. The main changes are focused on how configuration is loaded and overridden.

**Configuration precedence update:**

* Updated the documentation and code in `picas/picas_config.py` to specify that environment variables take precedence over configuration files, and implemented logic to override configuration file values with environment variables if they are set.
* Removed command line flags from the configuration precedence list in `examples/picasconfig_example.py` to match the new logic.